### PR TITLE
add chromeFlags

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 var prerender = require('./lib');
 
-var server = prerender();
+var server = prerender({
+  chromeFlags: ['--no-sandbox', '--headless', '--disable-gpu', '--remote-debugging-port=9222', '--hide-scrollbars']
+});
 
 server.use(prerender.sendPrerenderHeader());
 // server.use(prerender.blockResources());


### PR DESCRIPTION
Without these flags Chrome is not able to start:

```
Starting Prerender
Starting Chrome
Prerender server accepting requests on port 3000
Chrome connection closed... restarting Chrome
Chrome died immediately after restart... stopping Prerender
```

Reference prerender#450